### PR TITLE
Support displaying any extra_errors as an additional error message

### DIFF
--- a/results_uploader/src/mobly_result_converter.py
+++ b/results_uploader/src/mobly_result_converter.py
@@ -631,6 +631,24 @@ def _process_record(
                 MoblyResultstoreProperties.STACK_TRACE.value,
                 stack_trace,
             )
+
+    extra_errors = entry[records.TestResultEnums.RECORD_EXTRA_ERRORS]
+    if extra_errors is not None:
+        for _, error_details in extra_errors.items():
+            extra_error_element = ElementTree.SubElement(
+                testcase_element, ResultstoreTreeTags.ERROR.value
+            )
+            error_position = error_details[
+                records.TestResultEnums.RECORD_POSITION]
+            extra_error_element.set(
+                ResultstoreTreeAttributes.MESSAGE.value,
+                f'Error occurred at {error_position}.\nDetails: '
+                f'{error_details[records.TestResultEnums.RECORD_DETAILS]}',
+            )
+            stack_trace = error_details[
+                records.TestResultEnums.RECORD_STACKTRACE]
+            if stack_trace is not None:
+                extra_error_element.text = stack_trace
     return testcase_element
 
 


### PR DESCRIPTION
This allows results to properly show failures from e.g. setup_test and teardown_test

Example: https://btx.cloud.google.com/invocations/f5fa1ade-56e5-45b6-bf75-8ea90f6f8228/targets/CtsNfcHceMultiDeviceTestCases;config=default/tests