### PR TITLE
CI: Integrate workflow_triggers for mobly-android-partner-tools from cartland's fork

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish new release to PyPI
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
This Pull Request proposes to merge changes from the workflow_triggers branch (via cartland's fork of mobly-android-partner-tools). These changes implement updates to GitHub Actions workflows.