### PR TITLE
Ensure new user or --reset_gcp_login prompt sets the correct project ID

### DIFF
--- a/src/results_uploader/results_uploader.py
+++ b/src/results_uploader/results_uploader.py
@@ -493,6 +493,8 @@ def main(argv: list[str] | None = None) -> None:
     # Configure local GCP parameters
     if args.reset_gcp_login:
         _run_gcloud_command(['auth', 'application-default', 'revoke', '-q'])
+        if os.getenv(google.auth.environment_vars.CREDENTIALS):
+            del os.environ[google.auth.environment_vars.CREDENTIALS]
         _gcloud_login_and_set_project()
     try:
         creds, project_id = google.auth.default()


### PR DESCRIPTION
Also ensure that the same project ID is used for calling the GCS and Resultstore clients, by obtaining credentials from google.auth.default() only once.