### PR TITLE
Release notes for v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Mobly Android Partner Tools release history
 
+## 1.4.0 (2025-08-19)
+* [results_uploader] Enable batch uploading of multiple Mobly results.
+  * Upload any directory containing one or more independent Mobly run logs, and
+    the tool will generate a single link containing all of the results.
+  * If the test was executed as part of Android CTS, use `--cts` mode to attach 
+    CTS-specific data to the upload.
+
 ## 1.3.0 (2025-07-29)
 
 ### New

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mobly-android-partner-tools"
-version = "1.3.0"
+version = "1.4.0"
 description = "Command-line utilities used by Android partners to run packaged Mobly tests and upload test results."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/results_uploader/README.md
+++ b/src/results_uploader/README.md
@@ -52,6 +52,18 @@ add the following command-line option:
 mobly_runner my_test_suite --upload_results
 ```
 
+## Batch uploading
+If you run
+```bash
+results_uploader <folder_containing_multiple_mobly_artifacts>
+```
+
+The tool automatically searches recursively for all Mobly artifact folders
+contained within this directory, and creates a single BTX link with sub-entries
+for each of the results.
+
+You may use this feature to quickly share a set of related Mobly runs.
+
 ## Troubleshooting
 
 * If the link is missing, or the contents of the link are empty, check the

--- a/src/results_uploader/README.md
+++ b/src/results_uploader/README.md
@@ -59,8 +59,8 @@ results_uploader <folder_containing_multiple_mobly_artifacts>
 ```
 
 The tool automatically searches recursively for all Mobly artifact folders
-contained within this directory, and creates a single BTX link with sub-entries
-for each of the results.
+contained within this directory, and creates a single BTX link with a sub-entry
+for each folder.
 
 You may use this feature to quickly share a set of related Mobly runs.
 

--- a/src/results_uploader/data/mime.types
+++ b/src/results_uploader/data/mime.types
@@ -1,3 +1,3 @@
 # Configure the desired MIME types for Mobly log files in GCS
-text/plain      info debug log
+text/plain      info debug log textproto
 text/x-yaml     yaml yml


### PR DESCRIPTION
* [results_uploader] Enable batch uploading of multiple Mobly results.
  * Upload any directory containing one or more independent Mobly run logs, and
    the tool will generate a single link containing all of the results.
  * If the test was executed as part of Android CTS, use `--cts` mode to attach 
    CTS-specific data to the upload.
