### PR TITLE
Update mobly_result_converter.py to fix typo for `testCase`

### DIFF
--- a/src/results_uploader/mobly_result_converter.py
+++ b/src/results_uploader/mobly_result_converter.py
@@ -63,7 +63,7 @@ _INSPECTOR_BASIC_URL = (
     + 'targetId={{targetId}};'
     + 'configurationId={{configurationId}};'
     + 'actionId={{actionId}};'
-    + 'testcase='
+    + 'testCase='
 )
 
 class MoblyResultstoreProperties(enum.Enum):


### PR DESCRIPTION
Need to use `testCase` instead of `testcase` in Mobly Inspector URL.