### PR TITLE
Set 'OAUTHLIB_RELAX_TOKEN_SCOPE' env variable to resolve gcloud login error

### DIFF
--- a/src/results_uploader/results_uploader.py
+++ b/src/results_uploader/results_uploader.py
@@ -202,6 +202,7 @@ def _gcloud_login_and_set_project() -> None:
     while not project_id:
         project_id = input('Enter your GCP project ID: ')
     os.environ[google.auth.environment_vars.PROJECT] = project_id
+    os.environ['OAUTHLIB_RELAX_TOKEN_SCOPE'] = '1'
     _run_gcloud_command(
         ['config', 'set', 'project', project_id]
     )


### PR DESCRIPTION
Resolves the issue that affects certain users during 'gcloud login'

ERROR: gcloud crashed (Warning): Scope has changed from "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/sqlservice.login openid" to "https://www.googleapis.com/auth/userinfo.email openid".
